### PR TITLE
Start using Apache HC objects

### DIFF
--- a/src/main/resources/nolio/CreateRelease.py
+++ b/src/main/resources/nolio/CreateRelease.py
@@ -17,19 +17,26 @@ nolioUrl = nolioServer['url']
 
 credentials = CredentialsFallback(nolioServer, username, password).getCredentials()
 
+if appendTimestampToRelease:
+    if releaseName is None: 
+        finalReleaseName = time.strftime("%Y%m%d-%H%M%S")
+    else:
+        finalReleaseName = releaseName + " " + time.strftime("%Y%m%d-%H%M%S")
+else:
+    finalReleaseName = releaseName
+
 content = """
 {"environment":"%s","template":"%s","release":"%s","application":"%s","version":"%s","doStepsValidation":"%s","releaseType":"%s"}
 """ % (environmentName, templateName, releaseName, applicationName, version, str(doStepsValidation).lower(), releaseType)
 
-
 print "Sending content %s" % content
 
-nolioAPIUrl = nolioUrl + '/datamanagement/a/api/create-release'
-
-nolioResponse = XLRequest(nolioAPIUrl, 'POST', content, credentials['username'], credentials['password'], 'application/json').send()
+nolioContext = '/datamanagement/a/api/create-release/'
+httpRequest = HttpRequest(nolioServer, credentials['username'], credentials['password'])
+nolioResponse = httpRequest.post(nolioContext, content, contentType = 'application/json')
 
 if nolioResponse.status == RELEASE_CREATED_STATUS:
-    data = json.loads(nolioResponse.read())
+    data = json.loads(nolioResponse.getResponse())
     releaseId = data.get('id')
     releaseDescrition = data.get('description')
     releaseResult = data.get('result')

--- a/src/main/resources/nolio/RunRelease.py
+++ b/src/main/resources/nolio/RunRelease.py
@@ -24,12 +24,12 @@ content = """
 
 print "Sending content %s" % content
 
-nolioAPIUrl = nolioUrl + '/datamanagement/a/api/run-release'
-
-nolioResponse = XLRequest(nolioAPIUrl, 'POST', content, credentials['username'], credentials['password'], 'application/json').send()
+nolioContext = '/datamanagement/a/api/run-release/'
+httpRequest = HttpRequest(nolioServer, credentials['username'], credentials['password'])
+nolioResponse = httpRequest.post(nolioContext, content, contentType = 'application/json')
 
 if nolioResponse.status == RELEASE_CREATED_STATUS:
-    data = json.loads(nolioResponse.read())
+    data = json.loads(nolioResponse.getResponse())
     releaseId = data.get('id')
     releaseDescrition = data.get('description')
     releaseResult = data.get('result')

--- a/src/main/resources/nolio/RunTemplate.py
+++ b/src/main/resources/nolio/RunTemplate.py
@@ -17,25 +17,32 @@ nolioUrl = nolioServer['url']
 
 credentials = CredentialsFallback(nolioServer, username, password).getCredentials()
 
+if appendTimestampToRelease:
+    if releaseName is None: 
+        finalReleaseName = time.strftime("%Y%m%d-%H%M%S")
+    else:
+        finalReleaseName = releaseName + " " + time.strftime("%Y%m%d-%H%M%S")
+else:
+    finalReleaseName = releaseName
 
 # No properties (default)
 content = """
 {"environment":"%s","template":"%s","release":"%s","application":"%s","version":"%s","doStepsValidation":"%s","releaseType":"%s"}
-""" % (environmentName, templateName, releaseName, applicationName, version, str(doStepsValidation).lower(), releaseType)
+""" % (environmentName, templateName, finalReleaseName, applicationName, version, str(doStepsValidation).lower(), releaseType)
 
 # Properties have been defined.
 if props:
     content = """{"environment":"%s","template":"%s","release":"%s","application":"%s","version":"%s","doStepsValidation":"%s","releaseType":"%s","properties":{%s}}
-    """ % (environmentName, templateName, releaseName, applicationName, version, str(doStepsValidation).lower(), releaseType, props)
+    """ % (environmentName, templateName, finalReleaseName, applicationName, version, str(doStepsValidation).lower(), releaseType, props)
 
 print "Sending content %s" % content
 
-nolioAPIUrl = nolioUrl + '/datamanagement/a/api/run-template'
-
-nolioResponse = XLRequest(nolioAPIUrl, 'POST', content, credentials['username'], credentials['password'], 'application/json').send()
+nolioContext = '/datamanagement/a/api/run-template/'
+httpRequest = HttpRequest(nolioServer, credentials['username'], credentials['password'])
+nolioResponse = httpRequest.post(nolioContext, content, contentType = 'application/json')
 
 if nolioResponse.status == RELEASE_CREATED_STATUS:
-    data = json.loads(nolioResponse.read())
+    data = json.loads(nolioResponse.getResponse())
     releaseId = data.get('id')
     releaseDescription = data.get('description')
     releaseResult = data.get('result')

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -19,6 +19,7 @@
         <property name="templateName" category="input" label="Template Name" required="true" />
         <property name="applicationName" category="input" label="Application Name" required="true" />
         <property name="releaseName" category="input" label="Release Name" required="true" />
+        <property name="appendTimestampToRelease" category="input" label="Append timestamp to release" required="true" kind="boolean" />
         <property name="environmentName" category="input" label="Environment Name" required="true" />
         <property name="releaseType" category="input" label="Release Type" required="true" />
         <property name="version" category="input" label="Version" required="true" />
@@ -40,6 +41,8 @@
         <property name="templateName" category="input" label="Template Name" required="true" />
         <property name="applicationName" category="input" label="Application Name" required="true" />
         <property name="releaseName" category="input" label="Release Name" required="true" />
+        <property name="appendTimestampToRelease" category="input" label="Append timestamp to release" required="true" kind="boolean" />
+
         <property name="environmentName" category="input" label="Environment Name" required="true" />
         <property name="releaseType" category="input" label="Release Type" required="true" />
         <property name="version" category="input" label="Version" required="true" />


### PR DESCRIPTION
Hi made some changes to these python scripts such that they’ll be using HttpRequest object instead of deprecated XLRequest object based on Jython. This solved many SSL related issues for me. Note that I also included other changes you are aware off (namely the possibility to add timestamp + preparations for v2 support)
