### PR TITLE
Bugs fixed in ReleaseStatus task.

### DIFF
--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -81,8 +81,8 @@
         
         <property name="releaseId" category="input" label="Release Id" required="true" />
         <property name="version2" category="input" label="Version 2" kind="boolean" default="false" />
-        <property name="pollingInterval" category="input" label="Polling Interval" required="true" kind="integer" description="Polling interval in seconds to check release status."/>
-        <property name="numberOfTrials" category="input" label="Retry Count" required="true" kind="integer" description="Number of times to retry check for release status. '0' value disables retry counter."/>
+        <property name="pollingInterval" category="input" label="Polling Interval" required="true" kind="integer" description="Polling interval in seconds to check release status. By default '60'."/>
+        <property name="numberOfTrials" category="input" label="Retry Count" required="true" kind="integer" description="Number of times to retry check for release status. '0' value disables retry counter. By default '0'."/>
 
         <property name="releaseStatus" category="output"/> 
         <property name="releaseDescription" category="output"/> 


### PR DESCRIPTION
Added backward compatibility to tasks created by previous version plugin,
now null values are supported for numberOfTrials and pollingInterval
properties.

Added compatibility to CA Lisa 5.5.2 using REST API v1 calls,
releaseStatus expected values have been extended.
